### PR TITLE
Fix for "Tainted canvases may not be exported"

### DIFF
--- a/lib/feedback.ts
+++ b/lib/feedback.ts
@@ -243,7 +243,7 @@ export class Feedback {
 
     const data = {
       description: this._form[0].value,
-      screenshot: this._screenshotCanvas.toDataURL()
+      screenshot: this._screenshotCanvas.toDataURL("image/jpg")
     };
 
     fetch(this._options.endpoint, {


### PR DESCRIPTION
Fix for "Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported"